### PR TITLE
[Pull request] Swinging hook, Inventory upgrade

### DIFF
--- a/src/main/generated/assets/hookshot/lang/en_us.json
+++ b/src/main/generated/assets/hookshot/lang/en_us.json
@@ -8,7 +8,11 @@
   "config.hookshot.hookshot_cooldown": "Cooldown after using Hookshot",
   "config.hookshot.range_upgrade_multiplier": "Range Upgrade Multiplier",
   "config.hookshot.speed_upgrade_multiplier": "Speed Upgrade Multiplier",
+  "config.hookshot.use_swinging_hookshot": "Use Swinging Hookshot",
+  "config.hookshot.use_hookshot_gravity": "Use Hookshot Gravity",
   "config.hookshot.use_classic_hookshot_logic": "Use Old Hookshot Fire/Retract Logic",
+  "config.hookshot.swinging_hook_pull_up_strength": "Swinging Hook Pull Up Strength",
+  "config.hookshot.swinging_hook_pull_sideways_strength": "Swinging Hook Pull Sideways Strength",
   "death.attack.hookshot.bleeding": "%s bled to death",
   "death.attack.hookshot.bleeding.item": "%s bled to death",
   "death.attack.hookshot.bleeding.player": "%s bled to death whilst fighting %s",
@@ -20,6 +24,7 @@
   "hookshot.upgrade.hookshot.enderic": "Enderic",
   "hookshot.upgrade.hookshot.range": "Range",
   "hookshot.upgrade.hookshot.speed": "Speed",
+  "hookshot.upgrade.hookshot.inventory": "Inventory",
   "item.hookshot.black_hookshot": "Black Hookshot",
   "item.hookshot.blue_hookshot": "Blue Hookshot",
   "item.hookshot.brown_hookshot": "Brown Hookshot",
@@ -39,5 +44,7 @@
   "subtitles.hookshot.hookshot_reel": "Hookshot Reel",
   "tag.block.hookshot.unhookable": "Unable to attach hookshot",
   "tag.item.hookshot.hookshot_repair_items": "Hookshot Repair Items",
-  "tag.item.hookshot.hookshots": "Hookshots"
+  "tag.item.hookshot.hookshots": "Hookshots",
+  "key.hookshot.use": "Use Hookshot",
+  "key.categories.hookshot": "Hookshot"
 }

--- a/src/main/generated/data/hookshot/advancements/recipes/misc/inventory_upgrade_from_smithing.json
+++ b/src/main/generated/data/hookshot/advancements/recipes/misc/inventory_upgrade_from_smithing.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "hookshot:inventory_upgrade_from_smithing"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    },
+    "has_upgrade_item": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:chests"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "requirements": [
+    [
+      "has_upgrade_item",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "hookshot:inventory_upgrade_from_smithing"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/generated/data/hookshot/recipes/inventory_upgrade_from_smithing.json
+++ b/src/main/generated/data/hookshot/recipes/inventory_upgrade_from_smithing.json
@@ -1,0 +1,11 @@
+{
+  "type": "hookshot:upgrade_smithing",
+  "addition": {
+    "tag": "c:chests"
+  },
+  "apply_upgrade": "hookshot:inventory",
+  "base": {
+    "tag": "hookshot:hookshots"
+  },
+  "template": []
+}

--- a/src/main/java/dev/cammiescorner/hookshot/Hookshot.java
+++ b/src/main/java/dev/cammiescorner/hookshot/Hookshot.java
@@ -1,6 +1,7 @@
 package dev.cammiescorner.hookshot;
 
 import com.teamresourceful.resourcefulconfig.common.config.Configurator;
+import dev.cammiescorner.hookshot.networking.ModMessages;
 import dev.cammiescorner.hookshot.registry.*;
 import dev.cammiescorner.hookshot.util.UpgradesHelper;
 import dev.upcraft.sparkweave.api.registry.RegistryService;
@@ -28,6 +29,8 @@ public class Hookshot implements ModInitializer {
         HookshotRecipeSerializers.RECIPE_SERIALIZERS.accept(registryService);
         HookshotSoundEvents.SOUND_EVENTS.accept(registryService);
         HookshotUpgrades.UPGRADES.accept(registryService);
+
+        ModMessages.registerC2SPackets();
 
         ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.TOOLS_AND_UTILITIES).register(entries -> {
             entries.accept(HookshotItems.WHITE_HOOKSHOT.get());

--- a/src/main/java/dev/cammiescorner/hookshot/HookshotConfig.java
+++ b/src/main/java/dev/cammiescorner/hookshot/HookshotConfig.java
@@ -35,4 +35,16 @@ public final class HookshotConfig {
 
     @ConfigEntry(id = "speed_upgrade_multiplier", type = EntryType.DOUBLE, translation = "config.hookshot.speed_upgrade_multiplier")
     public static double speedUpgradeMultiplier = 1.5D;
+
+    @ConfigEntry(id = "use_swinging_hookshot", type = EntryType.BOOLEAN, translation = "config.hookshot.use_swinging_hookshot")
+    public static boolean useSwingingHookshot = false;
+
+    @ConfigEntry(id = "use_hookshot_gravity", type = EntryType.BOOLEAN, translation = "config.hookshot.use_hookshot_gravity")
+    public static boolean useHookshotGravity = false;
+
+    @ConfigEntry(id = "swinging_hook_pull_up_strength", type = EntryType.DOUBLE, translation = "config.hookshot.swinging_hook_pull_up_strength")
+    public static double swingingHookPullUpStrength = 1;
+
+    @ConfigEntry(id = "swinging_hook_pull_sideways_strength", type = EntryType.DOUBLE, translation = "config.hookshot.swinging_hook_pull_sideways_strength")
+    public static double swingingHookPullSidewaysStrength = 1;
 }

--- a/src/main/java/dev/cammiescorner/hookshot/client/HookshotClient.java
+++ b/src/main/java/dev/cammiescorner/hookshot/client/HookshotClient.java
@@ -6,25 +6,44 @@ import dev.cammiescorner.hookshot.client.entity.renderer.HookshotEntityRenderer;
 import dev.cammiescorner.hookshot.component.HookOwnerComponent;
 import dev.cammiescorner.hookshot.data.HookshotItemTags;
 import dev.cammiescorner.hookshot.item.HookshotItem;
+import dev.cammiescorner.hookshot.networking.ModMessages;
 import dev.cammiescorner.hookshot.registry.HookshotComponents;
 import dev.cammiescorner.hookshot.registry.HookshotEntities;
 import dev.cammiescorner.hookshot.registry.HookshotItems;
+import dev.cammiescorner.hookshot.registry.HookshotUpgrades;
 import dev.cammiescorner.hookshot.util.ColorHelper;
 import dev.cammiescorner.hookshot.util.Dyeable;
+import dev.cammiescorner.hookshot.util.UpgradesHelper;
 import dev.upcraft.sparkweave.api.registry.RegistrySupplier;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.renderer.item.ItemProperties;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.lwjgl.glfw.GLFW;
+import net.minecraft.resources.ResourceLocation;
 
 @Environment(EnvType.CLIENT)
 public class HookshotClient implements ClientModInitializer {
     public static final ModelLayerLocation HOOKSHOT = new ModelLayerLocation(Hookshot.id("hookshot"), "hookshot");
+
+    public static KeyMapping hookshotKey;
+
+    HookshotItem hookshot;
+
+    private static boolean wasUsingHookshot = false;
 
     @Override
     public void onInitializeClient() {
@@ -41,6 +60,72 @@ public class HookshotClient implements ClientModInitializer {
 
             registerHookModelOverride(item);
         });
+
+        hookshotKey = new KeyMapping(
+                "key.hookshot.use",
+                GLFW.GLFW_KEY_R,
+                "key.categories.hookshot"
+        );
+
+        // Register keybind
+        KeyBindingHelper.registerKeyBinding(hookshotKey);
+
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (hookshotKey.isDown()) {
+                if (!wasUsingHookshot) {
+                    if (client.player != null && client.level != null) {
+                        ItemStack hookshotStack = null;
+                        if (hookshot == null) {
+                            hookshotStack = getHookshotStack(client.player);
+
+                            if (hookshotStack == null)
+                                return;
+
+                            hookshot = getHookshot(hookshotStack);
+                        }
+
+                        if (hookshot == null)
+                            return;
+
+                        if (!UpgradesHelper.hasUpgrade(hookshotStack, HookshotUpgrades.INVENTORY.get()))
+                            return;
+
+                        ClientPlayNetworking.send(ModMessages.CREATE_HOOKSHOT_PACKET_ID, PacketByteBufs.create());
+                        wasUsingHookshot = true;
+                    }
+                }
+            }
+            else {
+                if (wasUsingHookshot) {
+                    if (hookshot == null) {
+                        return;
+                    }
+
+                    ClientPlayNetworking.send(ModMessages.REMOVE_HOOKSHOT_PACKET_ID, PacketByteBufs.create());
+                    hookshot = null;
+                    wasUsingHookshot = false;
+                }
+            }
+        });
+    }
+
+    private ItemStack getHookshotStack(Player player) {
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.getItem() instanceof HookshotItem) {
+                if (stack == player.getOffhandItem())
+                    return null;
+
+                return stack;
+            }
+        }
+        return null;
+    }
+
+    private HookshotItem getHookshot(ItemStack stack) {
+        if (stack.getItem() instanceof HookshotItem hookshotItem) {
+            return hookshotItem;
+        }
+        return null;
     }
 
     private static void registerHookModelOverride(Item item) {

--- a/src/main/java/dev/cammiescorner/hookshot/datagen/client/HookshotEnglishLanguageProvider.java
+++ b/src/main/java/dev/cammiescorner/hookshot/datagen/client/HookshotEnglishLanguageProvider.java
@@ -70,6 +70,12 @@ public class HookshotEnglishLanguageProvider extends SparkweaveLanguageProvider 
         translationBuilder.add("config.hookshot.durability_upgrade_multiplier", "Durability Upgrade Multiplier");
         translationBuilder.add("config.hookshot.range_upgrade_multiplier", "Range Upgrade Multiplier");
         translationBuilder.add("config.hookshot.speed_upgrade_multiplier", "Speed Upgrade Multiplier");
+        translationBuilder.add("config.hookshot.use_swinging_hookshot", "Use Swinging Hookshot");
+        translationBuilder.add("config.hookshot.use_hookshot_gravity", "Use Hookshot Gravity");
+        translationBuilder.add("config.hookshot.swinging_hook_pull_up_strength", "Swinging Hook Pull Up Strength");
+        translationBuilder.add("config.hookshot.swinging_hook_pull_sideways_strength", "Swinging Hook Pull Sideways Strength");
+        translationBuilder.add("key.hookshot.use", "Use Hookshot");
+        translationBuilder.add("key.categories.hookshot", "Hookshot");
     }
 
     private void upgrade(TranslationBuilder translationBuilder, Supplier<? extends HookshotUpgrade> upgrade, String translation) {

--- a/src/main/java/dev/cammiescorner/hookshot/entity/HookshotEntity.java
+++ b/src/main/java/dev/cammiescorner/hookshot/entity/HookshotEntity.java
@@ -36,16 +36,19 @@ public class HookshotEntity extends AbstractArrow {
     @Nullable
     private Entity hookedEntity;
     private ItemStack stack;
+    public boolean shotFromInventory;
 
     public HookshotEntity(Player owner, Level world) {
         super(HookshotEntities.HOOKSHOT.get(), owner, world);
-        this.setNoGravity(true);
+        if (!HookshotConfig.useHookshotGravity)
+            this.setNoGravity(true);
         this.setBaseDamage(0);
     }
 
     public HookshotEntity(EntityType<? extends HookshotEntity> type, Level world) {
         super(type, world);
-        this.setNoGravity(true);
+        if (!HookshotConfig.useHookshotGravity)
+            this.setNoGravity(true);
         this.setBaseDamage(0);
     }
 
@@ -69,7 +72,7 @@ public class HookshotEntity extends AbstractArrow {
         if(!owner.isAlive() || owner.distanceToSqr(this) > maxRange * maxRange) {
             return true;
         }
-        if(HookshotItem.findHeldHookshot(owner) == null) {
+        if(HookshotItem.findHeldHookshot(owner) == null && !shotFromInventory) {
             return true;
         }
 
@@ -113,26 +116,49 @@ public class HookshotEntity extends AbstractArrow {
                     origin = owner;
                 }
 
-                double brakeZone = (6D * (maxSpeed / HookshotConfig.defaultSpeed));
-                double pullSpeed = maxSpeed / 12D;
-                Vec3 distance = origin.position().subtract(target.position().add(0, target.getBbHeight() / 2, 0));
-
-                // TODO fix this spaghetti code
                 Vec3 motion;
-                if(distance.lengthSqr() >= brakeZone * brakeZone && UpgradesHelper.hasUpgrade(stack, HookshotUpgrades.AUTOMATIC.get())) {
-                    motion = distance.normalize().scale(pullSpeed);
+                if (HookshotConfig.useSwingingHookshot) {
+                    float currentDistance = target.distanceTo(origin);
+                    boolean belowHookshot = target.getY() < origin.getY();
+                    double ySpringStiffness, xzSpringStiffness;
+                    ySpringStiffness = xzSpringStiffness = 0.25D * HookshotConfig.swingingHookPullUpStrength;
+
+                    // Slow down players once close to the hook
+                    if (currentDistance < 2) {
+                        ySpringStiffness = 0;
+                        xzSpringStiffness = 0;
+                    }
+
+                    if (currentDistance < 4) {
+                        ySpringStiffness = 0.09D * HookshotConfig.swingingHookPullUpStrength;
+                        xzSpringStiffness = 0.09D * HookshotConfig.swingingHookPullSidewaysStrength;
+                    }
+                    // increase Y stiffness when descending at large speeds
+                    if (belowHookshot && target.getDeltaMovement().y < -1.5) {
+                        ySpringStiffness = 1.5D * HookshotConfig.swingingHookPullUpStrength;
+                    }
+                    if (belowHookshot && target.getDeltaMovement().y < -2) {
+                        ySpringStiffness = 4.0D * HookshotConfig.swingingHookPullUpStrength;
+                    }
+                    // Copied from lead code, same result as attaching a lead from hookshot to player
+                    double xDis = (origin.getX() - target.getX()) / (double)currentDistance;
+                    double yDis = (origin.getY() - target.getY()) / (double)currentDistance;
+                    double zDis = (origin.getZ() - target.getZ()) / (double)currentDistance;
+                    motion = target.getDeltaMovement().add(Math.copySign(xDis * xDis * xzSpringStiffness, xDis), Math.copySign(yDis * yDis * ySpringStiffness, yDis), Math.copySign(zDis * zDis * xzSpringStiffness, zDis));
                 }
                 else {
-                    motion = distance.scale(pullSpeed / brakeZone);
+                    double brakeZone = (6D * (maxSpeed / HookshotConfig.defaultSpeed));
+                    double pullSpeed = maxSpeed / 12D;
+                    Vec3 distance = origin.position().subtract(target.position().add(0, target.getBbHeight() / 2, 0));
+
+                    if (distance.lengthSqr() >= brakeZone * brakeZone && UpgradesHelper.hasUpgrade(stack, HookshotUpgrades.AUTOMATIC.get())) {
+                        motion = distance.normalize().scale(pullSpeed);
+                    } else {
+                        motion = distance.scale(pullSpeed / brakeZone);
+                    }
                 }
 
-                if (Math.abs(distance.y) < 0.1D) {
-                    motion = new Vec3(motion.x, 0, motion.z);
-                }
-
-                if (new Vec3(distance.x, 0, distance.z).length() < new Vec3(target.getBbWidth() / 2, 0, target.getBbWidth() / 2).length() / 1.4) {
-                    motion = new Vec3(0, motion.y, 0);
-                }
+                target.setDeltaMovement(motion);
 
                 if (HookshotConfig.hookshotCancelsFallDamage) {
                     target.fallDistance = 0;

--- a/src/main/java/dev/cammiescorner/hookshot/item/HookshotItem.java
+++ b/src/main/java/dev/cammiescorner/hookshot/item/HookshotItem.java
@@ -10,9 +10,14 @@ import dev.cammiescorner.hookshot.registry.HookshotComponents;
 import dev.cammiescorner.hookshot.registry.HookshotUpgrades;
 import dev.cammiescorner.hookshot.util.Dyeable;
 import dev.cammiescorner.hookshot.util.UpgradesHelper;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -51,6 +56,15 @@ public class HookshotItem extends Item implements Dyeable {
 			user.startUsingItem(hand);
 		}
 
+		HookshotEntity hookshotEntity = createHook(level, user, stack);
+
+		if (hookshotEntity != null)
+			hookshotEntity.shotFromInventory = false;
+
+		return InteractionResultHolder.sidedSuccess(stack, level.isClientSide());
+	}
+
+	public static HookshotEntity createHook(Level level, Player user, ItemStack stack) {
 		HookOwnerComponent hookOwner = user.getComponent(HookshotComponents.HOOK_OWNER);
 		if(!level.isClientSide()) {
 			if(!hookOwner.hasHook()) {
@@ -62,6 +76,7 @@ public class HookshotItem extends Item implements Dyeable {
 				level.addFreshEntity(hookshot);
 				level.playSound(user, user.blockPosition(), SoundEvents.ARROW_SHOOT, SoundSource.PLAYERS, 1F, 1F);
 				hookOwner.setHasHook(true);
+				return hookshot;
 			}
 			else if(HookshotConfig.useClassicHookshotLogic) {
 				hookOwner.setHasHook(false);
@@ -70,12 +85,35 @@ public class HookshotItem extends Item implements Dyeable {
 				}
 			}
 		}
+		return null;
+	}
 
-		return InteractionResultHolder.sidedSuccess(stack, level.isClientSide());
+	public static void recieveCreate(MinecraftServer server, ServerPlayer player, ServerGamePacketListenerImpl handler, FriendlyByteBuf buf, PacketSender responseSender) {
+		HookshotEntity hookshotEntity = createHook(player.level(), player, findHookshotInInventory(player));
+		if (hookshotEntity != null)
+			hookshotEntity.shotFromInventory = true;
+	}
+
+	public static void recieveRemove(MinecraftServer server, ServerPlayer player, ServerGamePacketListenerImpl handler, FriendlyByteBuf buf, PacketSender responseSender) {
+		removeHook(player);
+	}
+
+	@Nullable
+	private static ItemStack findHookshotInInventory(Player player) {
+		for (ItemStack stack : player.getInventory().items) {
+			if (stack.getItem() instanceof HookshotItem) {
+				return stack;
+			}
+		}
+		return null; // not found
 	}
 
 	@Override
 	public void releaseUsing(ItemStack stack, Level world, LivingEntity user, int remainingUseTicks) {
+		removeHook(user);
+	}
+
+	public static void removeHook(LivingEntity user) {
 		if(!HookshotConfig.useClassicHookshotLogic) {
 			HookshotComponents.HOOK_OWNER.maybeGet(user).ifPresent(hookOwner -> hookOwner.setHasHook(false));
 			if(user instanceof Player player && HookshotConfig.hookshotCooldown > 0) {

--- a/src/main/java/dev/cammiescorner/hookshot/networking/ModMessages.java
+++ b/src/main/java/dev/cammiescorner/hookshot/networking/ModMessages.java
@@ -1,0 +1,16 @@
+package dev.cammiescorner.hookshot.networking;
+
+import dev.cammiescorner.hookshot.item.HookshotItem;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.resources.ResourceLocation;
+
+public class ModMessages {
+    public static final ResourceLocation CREATE_HOOKSHOT_PACKET_ID = new ResourceLocation("hookshot", "create_hook");
+
+    public static final ResourceLocation REMOVE_HOOKSHOT_PACKET_ID = new ResourceLocation("hookshot", "remove_hook");
+
+    public static void registerC2SPackets() {
+        ServerPlayNetworking.registerGlobalReceiver(CREATE_HOOKSHOT_PACKET_ID, HookshotItem::recieveCreate);
+        ServerPlayNetworking.registerGlobalReceiver(REMOVE_HOOKSHOT_PACKET_ID, HookshotItem::recieveRemove);
+    }
+}

--- a/src/main/java/dev/cammiescorner/hookshot/registry/HookshotUpgrades.java
+++ b/src/main/java/dev/cammiescorner/hookshot/registry/HookshotUpgrades.java
@@ -16,5 +16,5 @@ public class HookshotUpgrades {
     public static final RegistrySupplier<HookshotUpgrade> ENDERIC = UPGRADES.register("enderic", HookshotUpgrade::new);
     public static final RegistrySupplier<HookshotUpgrade> RANGE = UPGRADES.register("range", HookshotUpgrade::new);
     public static final RegistrySupplier<HookshotUpgrade> SPEED = UPGRADES.register("speed", HookshotUpgrade::new);
-//    public static final RegistrySupplier<HookshotUpgrade> SWINGING = UPGRADES.register("swinging", HookshotUpgrade::new);
+    public static final RegistrySupplier<HookshotUpgrade> INVENTORY = UPGRADES.register("inventory", HookshotUpgrade::new);
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -55,7 +55,8 @@
     "resourcefulconfig": "*",
     "sparkweave": ">=0.8.4 <0.100.0",
     "cardinal-components-base": "*",
-    "cardinal-components-entity": "*"
+    "cardinal-components-entity": "*",
+    "fabric-key-binding-api-v1": "*"
   },
   "entrypoints": {
     "main": [


### PR DESCRIPTION
This adds a config to enable hook gravity and swinging hook to the 1.20.1 ver (code for it taken from the open pull request for 1.18)
Also adds a new upgrade called Inventory, lets the player throw the hook with a keybind if the hookshot is anywhere in their inventory